### PR TITLE
fix stop when session is still running

### DIFF
--- a/ext/screen_recorder/MCScreenRecorder.m
+++ b/ext/screen_recorder/MCScreenRecorder.m
@@ -98,7 +98,7 @@ default_file_name()
 
 - (BOOL)isStarted
 {
-  return self.output.isRecording;
+  return [self.output isRecording] || [self.session isRunning];
 }
 
 - (double) length

--- a/lib/screen_recorder/version.rb
+++ b/lib/screen_recorder/version.rb
@@ -1,4 +1,4 @@
 class ScreenRecorder
   # @return [String]
-  VERSION = '1.1.6'
+  VERSION = '1.1.7'
 end


### PR DESCRIPTION
Add pre-check in isStarted function, Because session controls the flow of data from AV input devices to outputs. And output controls the flow from output to file. When the output is not recording, the session maybe still running.